### PR TITLE
Fixed error when attempting to find folder resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+.gitignore
+/target
 /bin

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>CivModCore</artifactId>
 	<packaging>jar</packaging>
 	<description />
-	<version>1.1.91</version>
+	<version>1.1.92</version>
 	<name>CivModCore</name>
 	<url>https://github.com/Civcraft/CivModCore/</url>
 
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.8.3-R0.1-SNAPSHOT</version>
+			<version>1.8.8-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/src/vg/civcraft/mc/civmodcore/ACivMod.java
+++ b/src/vg/civcraft/mc/civmodcore/ACivMod.java
@@ -118,7 +118,7 @@ public abstract class ACivMod extends JavaPlugin implements Listener{
     public void onEnable() {
       registerEvents();
       registerCommands();
-      new NiceNames().loadNames();
+      new NiceNames().loadNames(this);
       //global_instance_ = this;
       info("Main Plugin Events and Config Command registered");
     }

--- a/src/vg/civcraft/mc/civmodcore/itemHandling/NiceNames.java
+++ b/src/vg/civcraft/mc/civmodcore/itemHandling/NiceNames.java
@@ -1,8 +1,8 @@
 package vg.civcraft.mc.civmodcore.itemHandling;
 
 import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.File;
+import java.io.FileReader;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -12,10 +12,14 @@ import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
 
+import vg.civcraft.mc.civmodcore.ACivMod;
+
 public class NiceNames {
 	private static Map<NameSearchObject, String> items;
 	private static Map<Enchantment, String> enchants;
 	private static Map<Enchantment, String> enchantAcronyms;
+	private static String enchantmentsFile = "/resources/enchantments.csv";
+	private static String materialsFile = "/resources/materials.csv";
 
 	private static class NameSearchObject {
 		private String data;
@@ -63,24 +67,28 @@ public class NiceNames {
 		return enchantAcronyms.get(enchant);
 	}
 
-	public void loadNames() {
+	public void loadNames(ACivMod plugin){
 		// item aliases
 		items = new HashMap<NiceNames.NameSearchObject, String>();
+		File materialsDir = new File(plugin.getDataFolder().getPath() + materialsFile);
 		try {
-			InputStream in = getClass().getResourceAsStream(
-					"/resources/materials.csv");
-			BufferedReader reader = new BufferedReader(
-					new InputStreamReader(in));
-			String line = reader.readLine();
-			while (line != null) {
-				String[] content = line.split(",");
-				NameSearchObject nso = new NameSearchObject(
-						Material.valueOf(content[1]),
-						Short.valueOf(content[3]), new LinkedList<String>());
-				items.put(nso, content[0]);
-				line = reader.readLine();
+			if(materialsDir.exists()){
+				BufferedReader reader = new BufferedReader(new FileReader(materialsDir));
+				String line = reader.readLine();
+				while (line != null) {
+					String[] content = line.split(",");
+					NameSearchObject nso = new NameSearchObject(
+							Material.valueOf(content[1]),
+							Short.valueOf(content[3]), new LinkedList<String>());
+					items.put(nso, content[0]);
+					line = reader.readLine();
+				}
+				reader.close();
 			}
-			reader.close();
+			else{
+				plugin.warning("materials.csv could not be loaded because it does not exist!");
+				plugin.warning("Attempted to read: " + materialsDir.getAbsolutePath());
+			}
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
@@ -88,20 +96,24 @@ public class NiceNames {
 		// enchantment aliases
 		enchants = new HashMap<Enchantment, String>();
 		enchantAcronyms = new HashMap<Enchantment, String>();
+		File enchantmentsDir = new File(plugin.getDataFolder().getPath() + enchantmentsFile);
 		try {
-			InputStream in = getClass().getResourceAsStream(
-					"/resources/enchantments.csv");
-			BufferedReader reader = new BufferedReader(
-					new InputStreamReader(in));
-			String line = reader.readLine();
-			while (line != null) {
-				String[] content = line.split(",");
-				Enchantment enchant = Enchantment.getByName(content[1]);
-				enchants.put(enchant, content[2]);
-				enchantAcronyms.put(enchant, content[0]);
-				line = reader.readLine();
+			if(enchantmentsDir.exists()){
+				BufferedReader reader = new BufferedReader(new FileReader(enchantmentsDir));
+				String line = reader.readLine();
+				while (line != null) {
+					String[] content = line.split(",");
+					Enchantment enchant = Enchantment.getByName(content[1]);
+					enchants.put(enchant, content[2]);
+					enchantAcronyms.put(enchant, content[0]);
+					line = reader.readLine();
+				}
+				reader.close();
 			}
-			reader.close();
+			else{
+				plugin.warning("enchantments.csv could not be loaded because it does not exist!");
+				plugin.warning("Attempted to read: " + enchantmentsDir.getAbsolutePath());
+			}
 		} catch (Exception e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
**Issue**
NameLayer threw a NullPointerException when calling from LoadNames() in NiceNames.java of CivModCore.

**Identified Culprit**
The file directories to resources/materials.csv and resources/enchantments.csv were declared as if they were relative file paths. This causes the system to look in the root directory for those files when they in fact exist in the plugin data folder "/plugins/NameLayer/resources/".

**Resolution**
Added plugin.getDataFolder().getPath() to relative file path for resources.

```
File enchantmentsDir = new File(plugin.getDataFolder().getPath() + enchantmentsFile);
```

**Additional Changes**
- Updated pom to use Spigot 1.8.8 dependency
- Added better File Exception handling and log messages
