### PR TITLE
Ninja edit: Find resources in /plugins/resources not /plugins/[ModNam…

### DIFF
--- a/src/vg/civcraft/mc/civmodcore/itemHandling/NiceNames.java
+++ b/src/vg/civcraft/mc/civmodcore/itemHandling/NiceNames.java
@@ -70,7 +70,7 @@ public class NiceNames {
 	public void loadNames(ACivMod plugin){
 		// item aliases
 		items = new HashMap<NiceNames.NameSearchObject, String>();
-		File materialsDir = new File(plugin.getDataFolder().getPath() + materialsFile);
+		File materialsDir = new File(plugin.getDataFolder().getParent() + materialsFile);
 		try {
 			if(materialsDir.exists()){
 				BufferedReader reader = new BufferedReader(new FileReader(materialsDir));
@@ -96,7 +96,7 @@ public class NiceNames {
 		// enchantment aliases
 		enchants = new HashMap<Enchantment, String>();
 		enchantAcronyms = new HashMap<Enchantment, String>();
-		File enchantmentsDir = new File(plugin.getDataFolder().getPath() + enchantmentsFile);
+		File enchantmentsDir = new File(plugin.getDataFolder().getParent() + enchantmentsFile);
 		try {
 			if(enchantmentsDir.exists()){
 				BufferedReader reader = new BufferedReader(new FileReader(enchantmentsDir));


### PR DESCRIPTION
Ninja edit: Find resources in /plugins/resources not /plugins/[ModName]/resources

I messed up the last change by only looking for resources in the  /plugins/[ModName] folder and /plugins folder. Fixed that now. Works with Mercury and NameLayer and BetterShards when trying to load from the same folder.
