### PR TITLE
Config impv

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>CivModCore</artifactId>
 	<packaging>jar</packaging>
 	<description />
-	<version>1.1.98</version>
+	<version>1.1.99</version>
 	<name>CivModCore</name>
 	<url>https://github.com/Civcraft/CivModCore/</url>
 

--- a/src/vg/civcraft/mc/civmodcore/annotations/CivConfig.java
+++ b/src/vg/civcraft/mc/civmodcore/annotations/CivConfig.java
@@ -7,10 +7,14 @@ import java.lang.annotation.Target;
 
 import vg.civcraft.mc.civmodcore.annotations.CivConfigType;
 
+/**
+ * If using {@link CivConfigType#Object} set default to be a valid YAML string, with
+ * a single top-level element "default"
+ */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface CivConfig {
   public String name();
-  public Object def() default null;
+  public String def() default "";
   public CivConfigType type() default CivConfigType.Bool;
 }

--- a/src/vg/civcraft/mc/civmodcore/annotations/CivConfig.java
+++ b/src/vg/civcraft/mc/civmodcore/annotations/CivConfig.java
@@ -11,6 +11,6 @@ import vg.civcraft.mc.civmodcore.annotations.CivConfigType;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface CivConfig {
   public String name();
-  public String def() default "";
+  public Object def() default null;
   public CivConfigType type() default CivConfigType.Bool;
 }

--- a/src/vg/civcraft/mc/civmodcore/annotations/CivConfigType.java
+++ b/src/vg/civcraft/mc/civmodcore/annotations/CivConfigType.java
@@ -6,5 +6,6 @@ public enum CivConfigType {
   Int,
   String,
   Long,
-  String_List
+  String_List,
+  Object
 }

--- a/src/vg/civcraft/mc/civmodcore/annotations/ConfigOption.java
+++ b/src/vg/civcraft/mc/civmodcore/annotations/ConfigOption.java
@@ -57,17 +57,24 @@ public class ConfigOption {
     }
   }
 
-  public Object convert(String value, Object defaultValue) {
+  public Object convert(Object value, Object defaultValue) {
     switch(type_) {
       case Bool:
-        return value.equals("1") || value.equalsIgnoreCase("true");
+        return (value instanceof Boolean ? value : 
+                value instanceof String ? (value.equals("1") || value.equalsIgnoreCase("true")) : false;
       case Int:
-        if (value.isEmpty()) {
-          return -1;
-        }
-        try {
-          return Integer.parseInt(value);
-        } catch(Exception e) {
+	    if (value instanceof Integer) {
+          return value;
+        } else if (value instanceof String) {
+          if (value.isEmpty()) {
+            return -1;
+          }
+          try {
+            return Integer.parseInt(value);
+          } catch(Exception e) {
+            return defaultValue;
+          }
+		} else {
           return defaultValue;
         }
       case Double:

--- a/src/vg/civcraft/mc/civmodcore/annotations/ConfigOption.java
+++ b/src/vg/civcraft/mc/civmodcore/annotations/ConfigOption.java
@@ -85,7 +85,7 @@ public class ConfigOption {
             value instanceof String ? 
                 (value.equals("1") || ((String)value).equalsIgnoreCase("true")) : false);
       case Int:
-	    if (value instanceof Integer) {
+        if (value instanceof Integer) {
           return value;
         } else if (value instanceof String) {
           if (((String) value).isEmpty()) {
@@ -96,7 +96,7 @@ public class ConfigOption {
           } catch(Exception e) {
             return defaultValue;
           }
-		} else {
+	} else {
           return defaultValue;
         }
       case Double:


### PR DESCRIPTION
Mostly making this pull to more easily test what plugins it breaks, if any.

Biggest change is allowing a plugin to specify as a default a String that gets interpreted by the YAML parser, allowing the specification of ConfigurationSerializable objects as valid Config parameters via annotation.
