### PR TITLE
Undoing a bit the logging changes from before. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>vg.civcraft.mc.civmodcore</groupId>
   <artifactId>CivModCore</artifactId>
-  <version>1.4.47</version>
+  <version>1.4.48</version>
 
   <name>CivModCore</name>
   <url>https://github.com/Civcraft/CivModCore/</url>

--- a/src/main/java/vg/civcraft/mc/civmodcore/ACivMod.java
+++ b/src/main/java/vg/civcraft/mc/civmodcore/ACivMod.java
@@ -2,13 +2,14 @@ package vg.civcraft.mc.civmodcore;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.logging.Logger;
+import java.util.logging.Level;
 
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.mcstats.Metrics;
+
 import vg.civcraft.mc.civmodcore.annotations.ConfigOption;
 import vg.civcraft.mc.civmodcore.chatDialog.ChatListener;
 import vg.civcraft.mc.civmodcore.chatDialog.DialogManager;
@@ -25,7 +26,7 @@ public abstract class ACivMod extends JavaPlugin {
 
 	public Config GetConfig() {
 		if (config_ == null) {
-			getLogger().info("Config not initialized. Most likely due to "
+			info("Config not initialized. Most likely due to "
 					+ "overriding onLoad and not calling super.onLoad()");
 		}
 		return config_;
@@ -92,12 +93,12 @@ public abstract class ACivMod extends JavaPlugin {
 	public void onLoad() {
 		classLoader = getClassLoader();
 		loadConfiguration();
-		getLogger().info("Configuration Loaded");
+		info("Configuration Loaded");
 	}
 
 	private void loadConfiguration() {
 		config_ = new Config(this);
-		getLogger().info("loaded config for: " + getPluginName() + "Config: " + (config_ != null));
+		info("loaded config for: {0} Config: {1}", getPluginName(), (config_ != null));
 	}
 
 	@Override
@@ -159,25 +160,75 @@ public abstract class ACivMod extends JavaPlugin {
 
 	protected abstract String getPluginName();
 
-	@Deprecated
+	/**
+	 * Simple SEVERE level logging.
+	 */
 	public void severe(String message) {
-		getLogger().severe("[" + getPluginName() + "] " + message);
+		getLogger().log(Level.SEVERE, message);
 	}
 
-	@Deprecated
+	/**
+	 * Simple SEVERE level logging with Throwable record.
+	 */
+	public void severe(String message, Throwable error) {
+		getLogger().log(Level.SEVERE, message, error);
+	}
+
+	/**
+	 * Simple WARNING level logging.
+	 */
 	public void warning(String message) {
-		getLogger().warning("[" + getPluginName() + "] " + message);
+		getLogger().log(Level.WARNING, message);
 	}
 
-	@Deprecated
+	/**
+	 * Simple WARNING level logging with Throwable record.
+	 */
+	public void warning(String message, Throwable error) {
+		getLogger().log(Level.WARNING, message, error);
+	}
+
+	/**
+	 * Simple WARNING level logging with ellipsis notation shortcut for defered injection argument array.
+	 */
+	public void warning(String message, Object...vars) {
+		getLogger().log(Level.WARNING, message, vars);
+	}
+
+	/**
+	 * Simple INFO level logging
+	 */
 	public void info(String message) {
-		getLogger().info("[" + getPluginName() + "] " + message);
+		getLogger().log(Level.INFO, message);
 	}
 
-	@Deprecated
+	/**
+	 * Simple INFO level logging with ellipsis notation shortcut for defered injection argument array.
+	 */
+	public void info(String message, Object...vars) {
+		getLogger().log(Level.INFO, message, vars);
+	}
+
+	/**
+	 * Live activatable debug message (using {@link Config#DebugLog} to decide) at INFO level.
+	 *
+	 * Skipped if DebugLog is false.
+	 */
 	public void debug(String message) {
 		if (config_.DebugLog) {
-			getLogger().info("[" + getPluginName() + "] " + message);
+			getLogger().log(Level.INFO, message);
+		}
+	}
+
+	/**
+	 * Live activatable debug message (using {@link Config#DebugLog} to decide) at INFO level
+	 * with ellipsis notation shorcut for defered injection argument array.
+	 *
+	 * Skipped if DebugLog is false.
+	 */
+	public void debug(String message, Object...vars) {
+		if (config_.DebugLog) {
+			getLogger().log(Level.INFO, message, vars);
 		}
 	}
 

--- a/src/main/java/vg/civcraft/mc/civmodcore/CivModCorePlugin.java
+++ b/src/main/java/vg/civcraft/mc/civmodcore/CivModCorePlugin.java
@@ -1,7 +1,5 @@
 package vg.civcraft.mc.civmodcore;
 
-import java.util.logging.Logger;
-
 import org.bukkit.plugin.java.JavaPlugin;
 
 /**
@@ -19,15 +17,6 @@ public class CivModCorePlugin extends JavaPlugin {
 		instance = this;
 	}
 
-	/**
-	 * Returns the logger for this plugin. Assumes the plugin has already been loaded.
-	 *
-	 * @return The logger for this plugin.
-	 */
-	public static Logger log() {
-		return getInstance().getLogger();
-	}
-	
 	public static CivModCorePlugin getInstance() {
 		return instance;
 	}

--- a/src/main/java/vg/civcraft/mc/civmodcore/inventorygui/ClickableInventory.java
+++ b/src/main/java/vg/civcraft/mc/civmodcore/inventorygui/ClickableInventory.java
@@ -1,10 +1,9 @@
 package vg.civcraft.mc.civmodcore.inventorygui;
 
-import static vg.civcraft.mc.civmodcore.CivModCorePlugin.log;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.logging.Logger;
 
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -25,6 +24,8 @@ import org.bukkit.inventory.ItemStack;
  */
 public class ClickableInventory {
 
+	private static final Logger log = Bukkit.getLogger();
+	
 	private static HashMap<UUID, ClickableInventory> openInventories = new HashMap<>();
 
 	private Inventory inventory;
@@ -40,7 +41,7 @@ public class ClickableInventory {
 	 */
 	public ClickableInventory(InventoryType type, String name) {
 		if (name != null && name.length() > 32) {
-			log().warning("ClickableInventory title exceeds Bukkit limits: " + name);
+			log.warning("ClickableInventory title exceeds Bukkit limits: " + name);
 			name = name.substring(0, 32);
 		}
 		inventory = Bukkit.createInventory(null, type, name);
@@ -59,7 +60,7 @@ public class ClickableInventory {
 	 */
 	public ClickableInventory(int size, String name) {
 		if (name != null && name.length() > 32) {
-			log().warning("ClickableInventory title exceeds Bukkit limits: " + name);
+			log.warning("ClickableInventory title exceeds Bukkit limits: " + name);
 			name = name.substring(0, 32);
 		}
 		inventory = Bukkit.createInventory(null, size, name);

--- a/src/main/java/vg/civcraft/mc/civmodcore/itemHandling/ItemMap.java
+++ b/src/main/java/vg/civcraft/mc/civmodcore/itemHandling/ItemMap.java
@@ -1,13 +1,12 @@
 package vg.civcraft.mc.civmodcore.itemHandling;
 
-import static vg.civcraft.mc.civmodcore.CivModCorePlugin.log;
-
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.logging.Logger;
 import java.util.Set;
 import java.util.UUID;
 
@@ -24,6 +23,7 @@ import net.minecraft.server.v1_10_R1.NBTTagLong;
 import net.minecraft.server.v1_10_R1.NBTTagShort;
 import net.minecraft.server.v1_10_R1.NBTTagString;
 
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.configuration.MemorySection;
@@ -48,6 +48,8 @@ import org.bukkit.inventory.PlayerInventory;
  */
 public class ItemMap {
 
+	private static final Logger log = Bukkit.getLogger();
+	
 	private HashMap<ItemStack, Integer> items;
 
 	private int totalItems;
@@ -461,7 +463,7 @@ public class ItemMap {
 				ItemStack toAdd = is.clone();
 				int addAmount = Math.min(amount, is.getMaxStackSize());
 				toAdd.setAmount(addAmount);
-				//log().info("Adding {0} as ItemStack", toAdd.toString());
+				//log.info("Adding {0} as ItemStack", toAdd.toString());
 				result.add(toAdd);
 				amount -= addAmount;
 			}
@@ -598,7 +600,7 @@ public class ItemMap {
 		net.minecraft.server.v1_10_R1.ItemStack s = CraftItemStack
 				.asNMSCopy(copy);
 		if (s == null) {
-			log().info("Attempted to create map conform copy of " + copy.toString()
+			log.info("Attempted to create map conform copy of " + copy.toString()
 					+ ", but couldn't because this item can't be held in inventories since Minecraft 1.8");
 			return null;
 		}
@@ -616,13 +618,13 @@ public class ItemMap {
 	 * @return Cloned ItemStack with amount set to amt and NBT set to map.
 	 */
 	public static ItemStack enrichWithNBT(ItemStack is, int amt, Map<String, Object> map) {
-		log().info("Received request to enrich " + is.toString());
+		log.info("Received request to enrich " + is.toString());
 		ItemStack copy = is.clone();
 		amt = (amt < 1 ? 1 : amt > is.getMaxStackSize() ? is.getMaxStackSize() : amt);
 		copy.setAmount(amt);
 		net.minecraft.server.v1_10_R1.ItemStack s = CraftItemStack.asNMSCopy(copy);
 		if (s == null) {
-			log().severe("Failed to create enriched copy of " + copy.toString());
+			log.severe("Failed to create enriched copy of " + copy.toString());
 			return null;
 		}
 
@@ -638,107 +640,107 @@ public class ItemMap {
 	}
 
 	public static NBTTagCompound mapToNBT(NBTTagCompound base, Map<String, Object> map) {
-		log().info("Representing map --> NBTTagCompound");
+		log.info("Representing map --> NBTTagCompound");
 		if (map == null || base == null) return base;
 		for (Map.Entry<String, Object> entry : map.entrySet()) {
 			Object object = entry.getValue();
 			if (object instanceof Map) {
-				log().info("Adding map at key " + entry.getKey());
+				log.info("Adding map at key " + entry.getKey());
 				base.set(entry.getKey(), mapToNBT(new NBTTagCompound(), (Map<String, Object>) object));
 			} else if (object instanceof MemorySection) {
-				log().info("Adding map from MemorySection at key " + entry.getKey());
+				log.info("Adding map from MemorySection at key " + entry.getKey());
 				base.set(entry.getKey(), mapToNBT(new NBTTagCompound(), ((MemorySection) object).getValues(true)));
 			} else if (object instanceof List) {
-				log().info("Adding list at key " + entry.getKey());
+				log.info("Adding list at key " + entry.getKey());
 				base.set(entry.getKey(), listToNBT(new NBTTagList(), (List<Object>) object));
 			} else if (object instanceof String) {
-				log().info("Adding String " + object + " at key " + entry.getKey());
+				log.info("Adding String " + object + " at key " + entry.getKey());
 				base.setString(entry.getKey(), (String) object);
 			} else if (object instanceof Double) {
-				log().info("Adding Double " + object + " at key " + entry.getKey());
+				log.info("Adding Double " + object + " at key " + entry.getKey());
 				base.setDouble(entry.getKey(), (Double) object);
 			} else if (object instanceof Float) {
-				log().info("Adding Float " + object + " at key " + entry.getKey());
+				log.info("Adding Float " + object + " at key " + entry.getKey());
 				base.setFloat(entry.getKey(), (Float) object);
 			} else if (object instanceof Boolean) {
-				log().info("Adding Boolean " + object + " at key " + entry.getKey());
+				log.info("Adding Boolean " + object + " at key " + entry.getKey());
 				base.setBoolean(entry.getKey(), (Boolean) object);
 			} else if (object instanceof Byte) {
-				log().info("Adding Byte " + object + " at key " + entry.getKey());
+				log.info("Adding Byte " + object + " at key " + entry.getKey());
 				base.setByte(entry.getKey(), (Byte) object);
 			} else if (object instanceof Short) {
-				log().info("Adding Byte " + object + " at key " + entry.getKey());
+				log.info("Adding Byte " + object + " at key " + entry.getKey());
 				base.setShort(entry.getKey(), (Short) object);
 			} else if (object instanceof Integer) {
-				log().info("Adding Integer " + object + " at key " + entry.getKey());
+				log.info("Adding Integer " + object + " at key " + entry.getKey());
 				base.setInt(entry.getKey(), (Integer) object);
 			} else if (object instanceof Long) {
-				log().info("Adding Long " + object + " at key " + entry.getKey());
+				log.info("Adding Long " + object + " at key " + entry.getKey());
 				base.setLong(entry.getKey(), (Long) object);
 			} else if (object instanceof byte[]) {
-				log().info("Adding bytearray at key " + entry.getKey());
+				log.info("Adding bytearray at key " + entry.getKey());
 				base.setByteArray(entry.getKey(), (byte[]) object);
 			} else if (object instanceof int[]) {
-				log().info("Adding intarray at key " + entry.getKey());
+				log.info("Adding intarray at key " + entry.getKey());
 				base.setIntArray(entry.getKey(), (int[]) object);
 			} else if (object instanceof UUID) {
-				log().info("Adding UUID " + object + " at key " + entry.getKey());
+				log.info("Adding UUID " + object + " at key " + entry.getKey());
 				base.a(entry.getKey(), (UUID) object);
 			} else if (object instanceof NBTBase) {
-				log().info("Adding nbtobject at key " + entry.getKey());
+				log.info("Adding nbtobject at key " + entry.getKey());
 				base.set(entry.getKey(), (NBTBase) object);
 			} else {
-				log().warning("Unrecognized entry in map-->NBT: " + object.toString());
+				log.warning("Unrecognized entry in map-->NBT: " + object.toString());
 			}
 		}
 		return base;
 	}
 
 	public static NBTTagList listToNBT(NBTTagList base, List<Object> list) {
-		log().info("Representing list --> NBTTagList");
+		log.info("Representing list --> NBTTagList");
 		if (list == null || base == null) return base;
 		for (Object object : list) {
 			if (object instanceof Map) {
-				log().info("Adding map to list");
+				log.info("Adding map to list");
 				base.add(mapToNBT(new NBTTagCompound(), (Map<String, Object>) object));
 			} else if (object instanceof MemorySection) {
-				log().info("Adding map from MemorySection to list");
+				log.info("Adding map from MemorySection to list");
 				base.add(mapToNBT(new NBTTagCompound(), ((MemorySection) object).getValues(true)));
 			} else if (object instanceof List) {
-				log().info("Adding list to list");
+				log.info("Adding list to list");
 				base.add(listToNBT(new NBTTagList(), (List<Object>) object));
 			} else if (object instanceof String) {
-				log().info("Adding string " + object + " to list");
+				log.info("Adding string " + object + " to list");
 				base.add(new NBTTagString((String) object));
 			} else if (object instanceof Double) {
-				log().info("Adding double " + object + " to list");
+				log.info("Adding double " + object + " to list");
 				base.add(new NBTTagDouble((Double) object));
 			} else if (object instanceof Float) {
-				log().info("Adding float " + object + " to list");
+				log.info("Adding float " + object + " to list");
 				base.add(new NBTTagFloat((Float) object));
 			} else if (object instanceof Byte) {
-				log().info("Adding byte " + object + " to list");
+				log.info("Adding byte " + object + " to list");
 				base.add(new NBTTagByte((Byte) object));
 			} else if (object instanceof Short) {
-				log().info("Adding short " + object + " to list");
+				log.info("Adding short " + object + " to list");
 				base.add(new NBTTagShort((Short) object));
 			} else if (object instanceof Integer) {
-				log().info("Adding integer " + object + " to list");
+				log.info("Adding integer " + object + " to list");
 				base.add(new NBTTagInt((Integer) object));
 			} else if (object instanceof Long) {
-				log().info("Adding long " + object + " to list");
+				log.info("Adding long " + object + " to list");
 				base.add(new NBTTagLong((Long) object));
 			} else if (object instanceof byte[]) {
-				log().info("Adding byte array to list");
+				log.info("Adding byte array to list");
 				base.add(new NBTTagByteArray((byte[]) object));
 			} else if (object instanceof int[]) {
-				log().info("Adding int array to list");
+				log.info("Adding int array to list");
 				base.add(new NBTTagIntArray((int[]) object));
 			} else if (object instanceof NBTBase) {
-				log().info("Adding nbt object to list");
+				log.info("Adding nbt object to list");
 				base.add((NBTBase) object);
 			} else {
-				log().warning("Unrecognized entry in list-->NBT: " + base.toString());
+				log.warning("Unrecognized entry in list-->NBT: " + base.toString());
 			}
 		}
 		return base;

--- a/src/main/java/vg/civcraft/mc/civmodcore/util/ClassUtility.java
+++ b/src/main/java/vg/civcraft/mc/civmodcore/util/ClassUtility.java
@@ -1,7 +1,5 @@
 package vg.civcraft.mc.civmodcore.util;
 
-import static vg.civcraft.mc.civmodcore.CivModCorePlugin.log;
-
 import java.io.IOException;
 import java.util.ArrayList;
 
@@ -19,7 +17,7 @@ public class ClassUtility {
 		try {
 			Package pack = plugin.getClass().getPackage();
 			if (pack == null) {
-				log().info("Package name REQUIRED for annotation loading");
+				plugin.info("Package name REQUIRED for annotation loading");
 			} else {
 
 				String packageName = pack.getName();
@@ -31,10 +29,10 @@ public class ClassUtility {
 					try {
 						clazz = Class.forName(info.getName(), true, classloader);
 					} catch (NoClassDefFoundError e) {
-					//	log().info("CivModCore failed to load class " + info.getName()
-					//			+ ", you could be missing a dependency. This message is more of an info "
-					//		+ "message useful for debugging. If you see this message you can usually "
-					//			+ "ignore it unless the plugin itself throws an error.");
+						// returning to "deprecated" method. The new logging needs rethinking.
+						plugin.info("CivModCore failed to load class {0}, you could be missing a dependency. This message is"
+								+ " more of an info message useful for debugging. If you see this message you can usually "
+								+ "ignore it unless the plugin itself throws an error.", info.getName());
 						continue;
 					}
 					if (ofType == null || ofType.isAssignableFrom(clazz)) {

--- a/src/main/java/vg/civcraft/mc/civmodcore/util/ConfigParsing.java
+++ b/src/main/java/vg/civcraft/mc/civmodcore/util/ConfigParsing.java
@@ -1,10 +1,10 @@
 package vg.civcraft.mc.civmodcore.util;
 
-import static vg.civcraft.mc.civmodcore.CivModCorePlugin.log;
-
 import java.util.List;
+import java.util.logging.Logger;
 
 import com.google.common.collect.Lists;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Location;
@@ -21,13 +21,17 @@ import org.bukkit.potion.PotionData;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.potion.PotionType;
+
 import vg.civcraft.mc.civmodcore.areas.EllipseArea;
 import vg.civcraft.mc.civmodcore.areas.GlobalYLimitedArea;
 import vg.civcraft.mc.civmodcore.areas.IArea;
 import vg.civcraft.mc.civmodcore.areas.RectangleArea;
 import vg.civcraft.mc.civmodcore.itemHandling.ItemMap;
 
+
 public class ConfigParsing {
+	
+	private static final Logger log = Bukkit.getLogger();
 
 	/**
 	 * Creates an itemmap containing all the items listed in the given config
@@ -61,7 +65,7 @@ public class ConfigParsing {
 			m = null;
 		} finally {
 			if (m == null) {
-				log().severe("Failed to find material of section " + current.getCurrentPath());
+				log.severe("Failed to find material of section " + current.getCurrentPath());
 				return im;
 			}
 		}
@@ -70,7 +74,7 @@ public class ConfigParsing {
 		toAdd.setDurability((short) durability);
 		ItemMeta meta = toAdd.getItemMeta();
 		if (meta == null) {
-			log().severe("No item meta found for" + current.getCurrentPath());
+			log.severe("No item meta found for" + current.getCurrentPath());
 		} else {
 			String name = current.getString("name");
 			if (name != null) {
@@ -146,7 +150,7 @@ public class ConfigParsing {
 						potType = PotionType.valueOf(potion.getString("type",
 								"AWKWARD"));
 					} catch (IllegalArgumentException e) {
-						log().warning(
+						log.warning(
 								"Expected potion type at "
 										+ potion.getCurrentPath() + ", but "
 										+ potion.getString("type")
@@ -241,8 +245,7 @@ public class ConfigParsing {
 					length = String.valueOf(days).length() + 1;
 					break;
 				default:
-					log()
-							.severe("Invalid time value in config:" + arg);
+					log.severe("Invalid time value in config:" + arg);
 			}
 			arg = arg.substring(0, arg.length() - length);
 		}
@@ -280,14 +283,14 @@ public class ConfigParsing {
 						.getConfigurationSection(name);
 				String type = configEffect.getString("type");
 				if (type == null) {
-					log().severe(
+					log.severe(
 							"Expected potion type to be specified, but found no \"type\" option at "
 									+ configEffect.getCurrentPath());
 					continue;
 				}
 				PotionEffectType effect = PotionEffectType.getByName(type);
 				if (effect == null) {
-					log().severe(
+					log.severe(
 							"Expected potion type to be specified at "
 									+ configEffect.getCurrentPath()
 									+ " but found " + type
@@ -304,24 +307,24 @@ public class ConfigParsing {
 
 	public static IArea parseArea(ConfigurationSection config) {
 		if (config == null) {
-			log().warning("Tried to parse area on null section");
+			log.warning("Tried to parse area on null section");
 			return null;
 		}
 		String type = config.getString("type");
 		if (type == null) {
-			log().warning("Found no area type at " + config.getCurrentPath());
+			log.warning("Found no area type at " + config.getCurrentPath());
 			return null;
 		}
 		int lowerYBound = config.getInt("lowerYBound", 0);
 		int upperYBound = config.getInt("upperYBound", 255);
 		String worldName = config.getString("world");
 		if (worldName == null) {
-			log().warning("Found no world specified for area at " + config.getCurrentPath());
+			log.warning("Found no world specified for area at " + config.getCurrentPath());
 			return null;
 		}
 		World world = Bukkit.getWorld(worldName);
 		if (world == null) {
-			log().warning("Found no world with name " + worldName + " as specified at " + config.getCurrentPath());
+			log.warning("Found no world with name " + worldName + " as specified at " + config.getCurrentPath());
 			return null;
 		}
 		Location center = null;
@@ -343,15 +346,15 @@ public class ConfigParsing {
 				break;
 			case "ELLIPSE":
 				if (center == null) {
-					log().warning("Found no center for area at " + config.getCurrentPath());
+					log.warning("Found no center for area at " + config.getCurrentPath());
 					return null;
 				}
 				if (xSize == -1) {
-					log().warning("Found no xSize for area at " + config.getCurrentPath());
+					log.warning("Found no xSize for area at " + config.getCurrentPath());
 					return null;
 				}
 				if (zSize == -1) {
-					log().warning("Found no zSize for area at " + config.getCurrentPath());
+					log.warning("Found no zSize for area at " + config.getCurrentPath());
 					return null;
 				}
 				area = new EllipseArea(lowerYBound, upperYBound, center, xSize,
@@ -359,22 +362,22 @@ public class ConfigParsing {
 				break;
 			case "RECTANGLE":
 				if (center == null) {
-					log().warning("Found no center for area at " + config.getCurrentPath());
+					log.warning("Found no center for area at " + config.getCurrentPath());
 					return null;
 				}
 				if (xSize == -1) {
-					log().warning("Found no xSize for area at " + config.getCurrentPath());
+					log.warning("Found no xSize for area at " + config.getCurrentPath());
 					return null;
 				}
 				if (zSize == -1) {
-					log().warning("Found no zSize for area at " + config.getCurrentPath());
+					log.warning("Found no zSize for area at " + config.getCurrentPath());
 					return null;
 				}
 				area = new RectangleArea(lowerYBound, upperYBound, center, xSize,
 						zSize);
 				break;
 			default:
-				log().warning("Invalid area type " + type + " at " + config.getCurrentPath());
+				log.warning("Invalid area type " + type + " at " + config.getCurrentPath());
 		}
 		return area;
 	}


### PR DESCRIPTION
A static utility import is of low value in the manner implemented; it bypasses the better pattern of leveraging the plugin's own getLogger(). I do concur with the sentiment of not holding a static instance of the abstract parent class and have retained that removal in spite of other consequent changes such as leveraging the Bukkit getLogger to split the difference, so to speak.

Note that without an slf4j config the bukkit standard logger appears to be a NOP.

I'd welcome other approaches. This PR will be live however as it addresses some startup issues introduced recently.
